### PR TITLE
Remove SCSS lint from default task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -388,7 +388,6 @@ module.exports = function(grunt) {
 			'unzip:jcropUnzip',
 			'concat:someFiles',
 			'copy:fromSource',
-			'scsslint',
 			'sass:dist',
 			'uglify:allJs',
 			'cssmin:allCss',


### PR DESCRIPTION
Those who may only want to do JS related tasks can't be expected to install Ruby.

