### PR TITLE
Fix systen information toolbar buttons position

### DIFF
--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 $doTask     = $displayData['doTask'];
 $class      = $displayData['class'];
 $text       = $displayData['text'];
-$floatRight = (strpos($doTask, 'index.php?option=com_config') !== false) ? ' float-sm-right' : '';
+$floatRight = strpos($doTask, 'option=com_config' !== false) ? ' float-sm-right' : '';
 ?>
 <button onclick="location.href='<?php echo $doTask; ?>';" class="btn btn-outline-danger btn-sm<?php echo $floatRight; ?>">
 	<span class="<?php echo $class; ?>"></span>


### PR DESCRIPTION
Pull Request for Issue #200 

### Summary of Changes

Download buttons on System Information toolbar are now in the correct position.
![screeny](https://cloud.githubusercontent.com/assets/2019801/20523549/86959cd8-b0ad-11e6-83df-b42a327b02d9.png)


