### PR TITLE
Move site title to middle

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -100,13 +100,13 @@ $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-
 					</div>
 
 					<div class="col-xs text-xs-center">
-						<a class="navbar-brand" href="<?php echo JUri::root(); ?>" title="<?php echo JText::sprintf('TPL_ATUM_PREVIEW', $sitename); ?>" target="_blank"><?php echo JHtml::_('string.truncate', $sitename, 28, false, false); ?>
-							<span class="icon-out-2 small"></span>
-						</a>
+						<jdoc:include type="modules" name="title" />
 					</div>
 
 					<div class="col-xs text-xs-right">
-						<jdoc:include type="modules" name="title" />
+						<a class="navbar-brand" href="<?php echo JUri::root(); ?>" title="<?php echo JText::sprintf('TPL_ATUM_PREVIEW', $sitename); ?>" target="_blank"><?php echo JHtml::_('string.truncate', $sitename, 28, false, false); ?>
+							<span class="icon-out-2 small"></span>
+						</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Pull Request for Issue #235 

### Summary of Changes

Switch the site title and site name around

![screeny](https://cloud.githubusercontent.com/assets/2019801/20569795/3c11e5c6-b199-11e6-9e6f-b33b7edc2b7d.png)


