### PR TITLE
Reduce legend font-size

### DIFF
--- a/administrator/templates/atum/css/template-rtl.css
+++ b/administrator/templates/atum/css/template-rtl.css
@@ -236,7 +236,8 @@ small,
   font-size: 0.8rem; }
 
 legend {
-  font-size: 1.2rem; }
+  font-size: 1.2rem;
+  font-weight: 700; }
 
 .j-main-container .alert {
   margin: 10px; }

--- a/administrator/templates/atum/css/template-rtl.css
+++ b/administrator/templates/atum/css/template-rtl.css
@@ -235,6 +235,9 @@ small,
 .small {
   font-size: 0.8rem; }
 
+legend {
+  font-size: 1.2rem; }
+
 .j-main-container .alert {
   margin: 10px; }
 

--- a/administrator/templates/atum/css/template.css
+++ b/administrator/templates/atum/css/template.css
@@ -236,7 +236,8 @@ small,
   font-size: 0.8rem; }
 
 legend {
-  font-size: 1.2rem; }
+  font-size: 1.2rem;
+  font-weight: 700; }
 
 .j-main-container .alert {
   margin: 10px; }

--- a/administrator/templates/atum/css/template.css
+++ b/administrator/templates/atum/css/template.css
@@ -235,6 +235,9 @@ small,
 .small {
   font-size: 0.8rem; }
 
+legend {
+  font-size: 1.2rem; }
+
 .j-main-container .alert {
   margin: 10px; }
 

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -31,4 +31,5 @@ small,
 
 legend {
   font-size: 1.2rem;
+  font-weight: 700;
 }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -28,3 +28,7 @@ small,
 .small {
   font-size: $font-size-sm;
 }
+
+legend {
+  font-size: 1.2rem;
+}


### PR DESCRIPTION
Pull Request for Issue #380 .

### Summary of Changes
Reduce legend font-size.

@svom 1.1rem made it difficult to distinguish the legends from the field labels so I used 1.2rem

