### PR TITLE
correct wrong string in login module

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -87,7 +87,7 @@ Text::script('JHIDE');
 
 		<?php if (!empty($langs)) : ?>
 			<div class="form-group">
-				<label class="text-white" for="lang" class="sr-only"><?php echo Text::_('JDEFAULTLANGUAGE'); ?></label>
+				<label class="text-white" for="lang" class="sr-only"><?php echo Text::_('MOD_LOGIN_LANGUAGE'); ?></label>
 				<?php echo $langs; ?>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
the wrong string was being used for the language select label

