### PR TITLE
Issue #410 fix: Sidebar menu background missing

### DIFF
--- a/administrator/templates/atum/css/template-rtl.css
+++ b/administrator/templates/atum/css/template-rtl.css
@@ -882,12 +882,14 @@ iframe {
     text-transform: uppercase;
     letter-spacing: 1px; }
   .main-nav .collapse-level-1 li {
-    position: relative; }
+    position: relative;
+    overflow: visible; }
     .main-nav .collapse-level-1 li:hover ul {
       display: block !important; }
   .main-nav .collapse-level-2 {
     position: absolute;
     top: 0;
+    bottom: auto;
     left: 100% !important;
     height: auto;
     padding: 2px 0;

--- a/administrator/templates/atum/css/template.css
+++ b/administrator/templates/atum/css/template.css
@@ -882,12 +882,14 @@ iframe {
     text-transform: uppercase;
     letter-spacing: 1px; }
   .main-nav .collapse-level-1 li {
-    position: relative; }
+    position: relative;
+    overflow: visible; }
     .main-nav .collapse-level-1 li:hover ul {
       display: block !important; }
   .main-nav .collapse-level-2 {
     position: absolute;
     top: 0;
+    bottom: auto;
     left: 100% !important;
     height: auto;
     padding: 2px 0;

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -199,6 +199,7 @@
 
     li {
       position: relative;
+      overflow:visible;
 
       &:hover ul {
         display: block !important;
@@ -210,6 +211,7 @@
   .collapse-level-2 {
     position: absolute;
     top: 0;
+    bottom:auto;
     left: 100% !important;
     height: auto;
     padding: 2px 0;


### PR DESCRIPTION
Pull Request for Issue # 410.

### Summary of Changes

Admin Template -> Sidebar Menu-> 3rd level menu background color was missing because of which all menu-items were not clearly visible. 

**Before Fix**
![before-fix](https://user-images.githubusercontent.com/30073416/40381352-1c0a1cfc-5e19-11e8-9de8-f6d912696221.png)

**After Fix**
![after-fix](https://user-images.githubusercontent.com/30073416/40381382-2c5322fc-5e19-11e8-9384-6a75e525b531.png)

### Testing Instructions

1. Log in Admin area
2. Hover on menu level 2 item which have child.

### Expected result

All menu-items of all levels should be clearly visible.

### Actual result

All menu-items of all levels are now clearly visible after fix.

### Documentation Changes Required - No
