### PR TITLE
Issue #411 feat: Sticky sidebar

### DIFF
--- a/administrator/templates/atum/css/template-rtl.css
+++ b/administrator/templates/atum/css/template-rtl.css
@@ -763,17 +763,34 @@ iframe {
 .sidebar-wrapper {
   display: flex;
   flex-direction: column;
-  position: relative;
   width: 250px;
   background-color: #2b5c91;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
-  transition: all .3s ease; }
+  transition: all .3s ease;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  z-index: 1041; }
   @media (max-width: 991.98px) {
     .sidebar-wrapper .main-nav {
       max-height: calc(100vh - 147px); } }
   .sidebar-wrapper .main-brand {
     padding: 15px;
     margin-top: auto; }
+  .sidebar-wrapper .main-nav-container {
+    max-height: calc(100vh - 60px);
+    overflow-y: auto;
+    overflow-x: hidden; }
+    .sidebar-wrapper .main-nav-container::-webkit-scrollbar {
+      width: 5px; }
+    .sidebar-wrapper .main-nav-container::-webkit-scrollbar-track {
+      background: #2b5c91;
+      box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5); }
+    .sidebar-wrapper .main-nav-container::-webkit-scrollbar-thumb {
+      background-color: #fff;
+      box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.3);
+      border-radius: 2px; }
 
 .menu-toggle-icon {
   width: 55px;

--- a/administrator/templates/atum/css/template.css
+++ b/administrator/templates/atum/css/template.css
@@ -763,17 +763,34 @@ iframe {
 .sidebar-wrapper {
   display: flex;
   flex-direction: column;
-  position: relative;
   width: 250px;
   background-color: #2b5c91;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
-  transition: all .3s ease; }
+  transition: all .3s ease;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  z-index: 1041; }
   @media (max-width: 991.98px) {
     .sidebar-wrapper .main-nav {
       max-height: calc(100vh - 147px); } }
   .sidebar-wrapper .main-brand {
     padding: 15px;
     margin-top: auto; }
+  .sidebar-wrapper .main-nav-container {
+    max-height: calc(100vh - 60px);
+    overflow-y: auto;
+    overflow-x: hidden; }
+    .sidebar-wrapper .main-nav-container::-webkit-scrollbar {
+      width: 5px; }
+    .sidebar-wrapper .main-nav-container::-webkit-scrollbar-track {
+      background: #2b5c91;
+      box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5); }
+    .sidebar-wrapper .main-nav-container::-webkit-scrollbar-thumb {
+      background-color: #fff;
+      box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.3);
+      border-radius: 2px; }
 
 .menu-toggle-icon {
   width: 55px;

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -11,11 +11,14 @@
 .sidebar-wrapper {
   display: flex;
   flex-direction: column;
-  position: relative;
   width: $sidebar-width;
   background-color: $atum-template-color-dark;
   box-shadow: $atum-box-shadow;
   transition: all .3s ease;
+  position:sticky;
+  top:0;
+  max-height:100vh;
+  z-index:1041;
 
   @include media-breakpoint-down(md) {
 
@@ -27,6 +30,26 @@
   .main-brand {
     padding: 15px;
     margin-top: auto;
+  }
+  .main-nav-container{
+	max-height:calc(100vh - 60px);
+	overflow-y:auto;
+	overflow-x: hidden;
+	
+	&::-webkit-scrollbar {
+      width: 5px;
+    }
+    
+    &::-webkit-scrollbar-track {
+      background:$atum-template-color-dark;
+      box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
+    }
+    
+    &::-webkit-scrollbar-thumb {
+      background-color: #fff;
+      box-shadow: inset 0 0 2px rgba(0,0,0,.3);
+      border-radius:2px;
+    }
   }
 }
 


### PR DESCRIPTION
Pull Request for Issue #411  .

### Summary of Changes

Sidebar menu should stay sticky after scrolling down the page.

**Before Fix** sidebar used to scroll up with the page
![before-fix](https://user-images.githubusercontent.com/30073416/40413968-c4593e80-5e94-11e8-953f-9a871ec3f71a.png)

**After fix - before the page is scrolled down**
![after-fix-before-scrolling-down-page](https://user-images.githubusercontent.com/30073416/40414056-f1e40790-5e94-11e8-8bdb-f6321af4e0b2.png)

**After fix - after the page is scrolled down** the menu should stick
![after-fix-after-scrolling-down-page](https://user-images.githubusercontent.com/30073416/40414099-0731fc06-5e95-11e8-8da4-79c9a8848301.png)

**After fix - scrollbar** if the no. of menu-items goes beyond the space available then scrollbar should be added.
![after-fix-with-scrollbar](https://user-images.githubusercontent.com/30073416/40414193-391dc2c2-5e95-11e8-9aab-5eb37ba6206d.png)

### Testing Instructions

1. Log in Admin area
2. Scroll down the page. the sidebar should stick to the top after reaching at top. and should nonstick once the scrolling up has reached the page top.
3. Toggle menu and repeat step 2.
4. Add some more menu-items , if the vertical space is not sufficient to accommodate, then scrollbar should be automatically added.

### Expected result

Sidebar menu should be easily accessible even after scrolling & toggling. 

### Actual result

Sidebar menu should be easily accessible even after scrolling & toggling. 

### Documentation Changes Required - No

